### PR TITLE
use PhotoTour mirror and no cuda required

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ HardNet model implementation in PyTorch for NIPS 2017 paper ["Working hard to kn
 [Notebook](notebook/convert_HardNet_to_JIT.ipynb)
 
 
+## Update April 2025
+
+The PhotoTour dataset is [no longer available](https://github.com/pytorch/vision/issues/8960) at original links. We use a [mirror from CTU in Prague](https://cmp.felk.cvut.cz/~mishkdmy/datasets/BrownPhotoTour/) instead.
+
 ## Update April 06 2018
 
 We have added small shift and rot augmentation, which improves results up to 1mAP point on HPatches. It is in HardNet.py, turn on by --augmentation=True. All the weight will be updated soon. Version, which is trained on Brown + HPatches + PS datasets is in progress, stay tuned :)

--- a/code/HardNet.py
+++ b/code/HardNet.py
@@ -40,6 +40,7 @@ from Utils import L2Norm, cv2_scale, np_reshape
 from Utils import str2bool
 import torch.nn as nn
 import torch.nn.functional as F
+from phototour import PhotoTour
 
 class CorrelationPenaltyLoss(nn.Module):
     def __init__(self):
@@ -165,6 +166,8 @@ if os.path.isdir(args.w1bsroot):
 os.environ['CUDA_VISIBLE_DEVICES'] = args.gpu_id
 
 args.cuda = not args.no_cuda and torch.cuda.is_available()
+device = torch.device("cuda" if args.cuda else "cpu")
+
 
 print (("NOT " if not args.cuda else "") + "Using cuda")
 
@@ -182,12 +185,13 @@ random.seed(args.seed)
 torch.manual_seed(args.seed)
 np.random.seed(args.seed)
 
-class TripletPhotoTour(dset.PhotoTour):
+class TripletPhotoTour(PhotoTour):
     """
     From the PhotoTour Dataset it generates triplet samples
     note: a triplet is composed by a pair of matching images and one of
     different class.
     """
+
     def __init__(self, train=True, transform=None, batch_size = None,load_random_triplets = False,  *arg, **kw):
         super(TripletPhotoTour, self).__init__(*arg, **kw)
         self.transform = transform
@@ -195,6 +199,7 @@ class TripletPhotoTour(dset.PhotoTour):
         self.train = train
         self.n_triplets = args.n_triplets
         self.batch_size = batch_size
+
 
         if self.train:
             print('Generating {} triplets'.format(self.n_triplets))
@@ -397,13 +402,12 @@ def train(train_loader, model, optimizer, epoch, logger, load_triplets  = False)
         else:
             data_a, data_p = data
 
-        if args.cuda:
-            data_a, data_p  = data_a.cuda(), data_p.cuda()
-            data_a, data_p = Variable(data_a), Variable(data_p)
-            out_a = model(data_a)
-            out_p = model(data_p)
+        data_a, data_p  = data_a.to(device), data_p.to(device)
+        data_a, data_p = Variable(data_a), Variable(data_p)
+        out_a = model(data_a)
+        out_p = model(data_p)
         if load_triplets:
-            data_n  = data_n.cuda()
+            data_n  = data_n.to(device)
             data_n = Variable(data_n)
             out_n = model(data_n)
 
@@ -460,8 +464,7 @@ def test(test_loader, model, epoch, logger, logger_test_name):
     pbar = tqdm(enumerate(test_loader))
     for batch_idx, (data_a, data_p, label) in pbar:
 
-        if args.cuda:
-            data_a, data_p = data_a.cuda(), data_p.cuda()
+        data_a, data_p = data_a.to(device), data_p.to(device)
 
         data_a, data_p, label = Variable(data_a, volatile=True), \
                                 Variable(data_p, volatile=True), Variable(label)
@@ -522,8 +525,7 @@ def main(train_loader, test_loaders, model, logger, file_logger):
     #if (args.enable_logging):
     #    file_logger.log_string('logs.txt', '\nparsed options:\n{}\n'.format(vars(args)))
 
-    if args.cuda:
-        model.cuda()
+    model = model.to(device)
 
     optimizer1 = create_optimizer(model.features, args.lr)
 

--- a/code/Losses.py
+++ b/code/Losses.py
@@ -62,7 +62,7 @@ def loss_L2Net(anchor, positive, anchor_swap = False,  margin = 1.0, loss_type =
     assert anchor.dim() == 2, "Inputd must be a 2D matrix."
     eps = 1e-8
     dist_matrix = distance_matrix_vector(anchor, positive)
-    eye = torch.autograd.Variable(torch.eye(dist_matrix.size(1))).cuda()
+    eye = torch.autograd.Variable(torch.eye(dist_matrix.size(1))).to(anchor.device)
 
     # steps to filter out same patches that occur in distance matrix as negatives
     pos1 = torch.diag(dist_matrix)
@@ -93,7 +93,7 @@ def loss_HardNet(anchor, positive, anchor_swap = False, anchor_ave = False,\
     assert anchor.dim() == 2, "Inputd must be a 2D matrix."
     eps = 1e-8
     dist_matrix = distance_matrix_vector(anchor, positive) +eps
-    eye = torch.autograd.Variable(torch.eye(dist_matrix.size(1))).cuda()
+    eye = torch.autograd.Variable(torch.eye(dist_matrix.size(1))).to(anchor.device)
 
     # steps to filter out same patches that occur in distance matrix as negatives
     pos1 = torch.diag(dist_matrix)
@@ -129,7 +129,7 @@ def loss_HardNet(anchor, positive, anchor_swap = False, anchor_ave = False,\
             min_neg = torch.min(min_neg,min_neg2)
         min_neg = min_neg.squeeze(0)
     elif batch_reduce == 'random':
-        idxs = torch.autograd.Variable(torch.randperm(anchor.size()[0]).long()).cuda()
+        idxs = torch.autograd.Variable(torch.randperm(anchor.size()[0]).long()).to(anchor.device)
         min_neg = dist_without_min_on_diag.gather(1,idxs.view(-1,1))
         if anchor_swap:
             min_neg2 = torch.t(dist_without_min_on_diag).gather(1,idxs.view(-1,1)) 

--- a/code/phototour.py
+++ b/code/phototour.py
@@ -1,0 +1,233 @@
+
+from torchvision.datasets.vision import VisionDataset
+from torchvision.datasets.utils import download_url
+from typing import Any, Callable, Optional, Tuple, Union, List
+import os
+from PIL import Image
+import numpy as np
+import torch
+
+
+def read_image_file(data_dir: str, image_ext: str, n: int) -> torch.Tensor:
+    """Return a Tensor containing the patches"""
+
+    def PIL2array(_img: Image.Image) -> np.ndarray:
+        """Convert PIL image type to numpy 2D array"""
+        return np.array(_img.getdata(), dtype=np.uint8).reshape(64, 64)
+
+    def find_files(_data_dir: str, _image_ext: str) -> List[str]:
+        """Return a list with the file names of the images containing the patches"""
+        files = []
+        # find those files with the specified extension
+        for file_dir in os.listdir(_data_dir):
+            if file_dir.endswith(_image_ext):
+                files.append(os.path.join(_data_dir, file_dir))
+        return sorted(files)  # sort files in ascend order to keep relations
+
+    patches = []
+    list_files = find_files(data_dir, image_ext)
+
+    for fpath in list_files:
+        img = Image.open(fpath)
+        for y in range(0, img.height, 64):
+            for x in range(0, img.width, 64):
+                patch = img.crop((x, y, x + 64, y + 64))
+                patches.append(PIL2array(patch))
+    return torch.ByteTensor(np.array(patches[:n]))
+
+
+def read_info_file(data_dir: str, info_file: str) -> torch.Tensor:
+    """Return a Tensor containing the list of labels
+    Read the file and keep only the ID of the 3D point.
+    """
+    with open(os.path.join(data_dir, info_file)) as f:
+        labels = [int(line.split()[0]) for line in f]
+    return torch.LongTensor(labels)
+
+
+def read_matches_files(data_dir: str, matches_file: str) -> torch.Tensor:
+    """Return a Tensor containing the ground truth matches
+    Read the file and keep only 3D point ID.
+    Matches are represented with a 1, non matches with a 0.
+    """
+    matches = []
+    with open(os.path.join(data_dir, matches_file)) as f:
+        for line in f:
+            line_split = line.split()
+            matches.append([int(line_split[0]), int(line_split[3]), int(line_split[1] == line_split[4])])
+    return torch.LongTensor(matches)
+
+class PhotoTour(VisionDataset):
+    """`Multi-view Stereo Correspondence <http://matthewalunbrown.com/patchdata/patchdata.html>`_ Dataset.
+
+    .. note::
+
+        We only provide the newer version of the dataset, since the authors state that it
+
+            is more suitable for training descriptors based on difference of Gaussian, or Harris corners, as the
+            patches are centred on real interest point detections, rather than being projections of 3D points as is the
+            case in the old dataset.
+
+        The original dataset is available under http://phototour.cs.washington.edu/patches/default.htm.
+
+
+    Args:
+        root (string): Root directory where images are.
+        name (string): Name of the dataset to load.
+        transform (callable, optional): A function/transform that  takes in an PIL image
+            and returns a transformed version.
+        download (bool, optional): If true, downloads the dataset from the internet and
+            puts it in root directory. If dataset is already downloaded, it is not
+            downloaded again.
+
+    """
+
+    urls = {
+            "notredame_harris": [
+                "https://cmp.felk.cvut.cz/~mishkdmy/datasets/BrownPhotoTour/notredame_harris.zip",
+                "notredame_harris.zip",
+                "f139ca4e4101d558c31c3233233c2a06",
+            ],
+            "yosemite_harris": [
+                "https://cmp.felk.cvut.cz/~mishkdmy/datasets/BrownPhotoTour/yosemite_harris.zip",
+                "yosemite_harris.zip",
+                "a9f8a48c96dbe9e5703f21c1de764173",
+            ],
+            "liberty_harris": [
+                "https://cmp.felk.cvut.cz/~mishkdmy/datasets/BrownPhotoTour/liberty_harris.zip",
+                "liberty_harris.zip",
+                "01c32c4d98493a95f23159923ff0ca39",
+            ],
+            "notredame": [
+                "https://cmp.felk.cvut.cz/~mishkdmy/datasets/BrownPhotoTour/notredame/notredame.zip",
+                "notredame.zip",
+                "3fd38e77cd32a43051525532c83460ef",
+            ],
+            "yosemite": ["https://cmp.felk.cvut.cz/~mishkdmy/datasets/BrownPhotoTour/yosemite.zip",
+                         "yosemite.zip", 
+                         "97f1ecc08928cdf2dba220939778779e"],
+            "liberty": ["https://cmp.felk.cvut.cz/~mishkdmy/datasets/BrownPhotoTour/liberty.zip",
+                        "liberty.zip",
+                        "abb7b7e7c8f58b953f9d10dce2cb5e9c"],
+    }
+    means = {
+        "notredame": 0.4854,
+        "yosemite": 0.4844,
+        "liberty": 0.4437,
+        "notredame_harris": 0.4854,
+        "yosemite_harris": 0.4844,
+        "liberty_harris": 0.4437,
+    }
+    stds = {
+        "notredame": 0.1864,
+        "yosemite": 0.1818,
+        "liberty": 0.2019,
+        "notredame_harris": 0.1864,
+        "yosemite_harris": 0.1818,
+        "liberty_harris": 0.2019,
+    }
+    lens = {
+        "notredame": 468159,
+        "yosemite": 633587,
+        "liberty": 450092,
+        "liberty_harris": 379587,
+        "yosemite_harris": 450912,
+        "notredame_harris": 325295,
+    }
+    image_ext = "bmp"
+    info_file = "info.txt"
+    matches_files = "m50_100000_100000_0.txt"
+
+    def __init__(
+        self, root: str, name: str, train: bool = True, transform: Optional[Callable] = None, download: bool = False
+    ) -> None:
+        super().__init__(root, transform=transform)
+        self.name = name
+        self.data_dir = os.path.join(self.root, name)
+        self.data_down = os.path.join(self.root, f"{name}.zip")
+        self.data_file = os.path.join(self.root, f"{name}.pt")
+
+        self.train = train
+        self.mean = self.means[name]
+        self.std = self.stds[name]
+
+        if download:
+            self.download()
+
+        if not self._check_datafile_exists():
+            self.cache()
+
+        # load the serialized data
+        self.data, self.labels, self.matches = torch.load(self.data_file)
+
+    def __getitem__(self, index: int) -> Union[torch.Tensor, Tuple[Any, Any, torch.Tensor]]:
+        """
+        Args:
+            index (int): Index
+
+        Returns:
+            tuple: (data1, data2, matches)
+        """
+        if self.train:
+            data = self.data[index]
+            if self.transform is not None:
+                data = self.transform(data)
+            return data
+        m = self.matches[index]
+        data1, data2 = self.data[m[0]], self.data[m[1]]
+        if self.transform is not None:
+            data1 = self.transform(data1)
+            data2 = self.transform(data2)
+        return data1, data2, m[2]
+
+    def __len__(self) -> int:
+        return len(self.data if self.train else self.matches)
+
+    def _check_datafile_exists(self) -> bool:
+        return os.path.exists(self.data_file)
+
+    def _check_downloaded(self) -> bool:
+        return os.path.exists(self.data_dir)
+
+    def download(self) -> None:
+        if self._check_datafile_exists():
+            print(f"# Found cached data {self.data_file}")
+            return
+
+        if not self._check_downloaded():
+            # download files
+            url = self.urls[self.name][0]
+            filename = self.urls[self.name][1]
+            md5 = self.urls[self.name][2]
+            fpath = os.path.join(self.root, filename)
+            download_url(url, self.root, filename, md5)
+
+            print(f"# Extracting data {self.data_down}\n")
+
+            import zipfile
+
+            with zipfile.ZipFile(fpath) as zip:
+                for zip_info in zip.infolist():
+                    if zip_info.is_dir():
+                        continue
+                    zip_info.filename = os.path.basename(zip_info.filename)
+                    zip.extract(zip_info, self.data_dir)
+
+            os.unlink(fpath)
+
+    def cache(self) -> None:
+        # process and save as torch files
+        print(f"# Caching data {self.data_file}")
+
+        dataset = (
+            read_image_file(self.data_dir, self.image_ext, self.lens[self.name]),
+            read_info_file(self.data_dir, self.info_file),
+            read_matches_files(self.data_dir, self.matches_files),
+        )
+
+        with open(self.data_file, "wb") as f:
+            torch.save(dataset, f)
+
+    def extra_repr(self) -> str:
+        split = "Train" if self.train is True else "Test"
+        return f"Split: {split}"


### PR DESCRIPTION
The PhotoTour dataset is [no longer available](https://github.com/pytorch/vision/issues/8960) at original links. We use a [mirror from CTU in Prague](https://cmp.felk.cvut.cz/~mishkdmy/datasets/BrownPhotoTour/) instead.

Also remove the cuda as hard requirement, so one can run MPS instead.